### PR TITLE
Only create a new engine if scripts have been modified

### DIFF
--- a/src/community/script/core/src/main/java/org/geoserver/script/ScriptFileWatcher.java
+++ b/src/community/script/core/src/main/java/org/geoserver/script/ScriptFileWatcher.java
@@ -24,15 +24,30 @@ import org.geoserver.platform.FileWatcher;
 public class ScriptFileWatcher extends FileWatcher<ScriptEngine> {
 
     ScriptManager scriptMgr;
+    ScriptEngine engine;
 
     public ScriptFileWatcher(File file, ScriptManager scriptMgr) {
         super(file);
         this.scriptMgr = scriptMgr;
     }
+    
+    /**
+     * Create a new script engine and evaluate the script if modified since the
+     * last call to read.  Otherwise return the existing engine.
+     * @return
+     * @throws IOException
+     */
+    public ScriptEngine readIfModified() throws IOException {
+        if (isModified()) {
+            return read();
+        } else {
+            return engine;
+        }
+    }
 
     @Override
     protected ScriptEngine parseFileContents(InputStream in) throws IOException {
-        ScriptEngine engine = scriptMgr.createNewEngine(getFile());
+        engine = scriptMgr.createNewEngine(getFile());
         try {
             engine.eval(new InputStreamReader(in));
         } catch (ScriptException e) {

--- a/src/community/script/core/src/main/java/org/geoserver/script/function/ScriptFunction.java
+++ b/src/community/script/core/src/main/java/org/geoserver/script/function/ScriptFunction.java
@@ -63,7 +63,7 @@ public class ScriptFunction {
                 for (Expression e : getParameters()) {
                     args.add(e.evaluate(object));
                 }
-                return hook.run(object, args, watcher.read());
+                return hook.run(object, args, watcher.readIfModified());
             }
             catch(Exception e) {
                 throw new RuntimeException(e);

--- a/src/community/script/core/src/main/java/org/geoserver/script/wps/ScriptProcess.java
+++ b/src/community/script/core/src/main/java/org/geoserver/script/wps/ScriptProcess.java
@@ -37,7 +37,7 @@ public class ScriptProcess implements Process {
     Name name;
     
     /** watcher for file changes */
-    FileWatcher<ScriptEngine> fw;
+    ScriptFileWatcher fw;
     
     /** script manager */
     ScriptManager scriptMgr;
@@ -54,23 +54,23 @@ public class ScriptProcess implements Process {
     }
 
     public String getTitle() throws ScriptException, IOException {
-        return hook.getTitle(fw.read());
+        return hook.getTitle(fw.readIfModified());
     }
 
     String getVersion() throws ScriptException, IOException {
-        return hook.getVersion(fw.read());
+        return hook.getVersion(fw.readIfModified());
     }
 
     public String getDescription() throws ScriptException, IOException {
-        return hook.getDescription(fw.read());
+        return hook.getDescription(fw.readIfModified());
     }
 
     public Map<String, Parameter<?>> getInputs() throws ScriptException, IOException {
-        return hook.getInputs(fw.read());
+        return hook.getInputs(fw.readIfModified());
     }
 
     public Map<String, Parameter<?>> getOutputs() throws ScriptException, IOException {
-        return hook.getOutputs(fw.read());
+        return hook.getOutputs(fw.readIfModified());
     }
 
     @Override
@@ -78,7 +78,7 @@ public class ScriptProcess implements Process {
             ProgressListener monitor) throws ProcessException {
 
         try {
-            return hook.run(input, fw.read());
+            return hook.run(input, fw.readIfModified());
         } catch (Exception e) {
             throw new ProcessException(e);
         }


### PR DESCRIPTION
Though a file watcher is created for scripts, `isModified` is never called.  In the case of the WPS hook, this means the script is evaluated once each time title, description, inputs, outputs, etc are accessed (instead of once per modification).

Tests still pass with this change.
