### PR TITLE
Open STRICT_STYLE=false to account for clients using restricted characters [GEOS-6811]

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CatalogFacade.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogFacade.java
@@ -712,6 +712,8 @@ public interface CatalogFacade {
     /**
      * Loads a style from persistent storage by specifying its name.
      * 
+     * This only checks the global styles directory.
+     * 
      * @param name The name of the style.
      * 
      * @return The style, or <code>null</code> if no such style exists

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -1280,15 +1280,28 @@ public class CatalogImpl implements Catalog {
         return facade.getStyle(id);
     }
 
+    static final String REPLACE = "[:]";
+    static final boolean STRICT_STYLE = Boolean.valueOf(System.getProperty("STRICT_STYLE", "true"));
     public StyleInfo getStyleByName(String name) {
         StyleInfo result = null;
         int colon = name.indexOf(':');
         if (colon != -1) {
-            // search by resource name
             String prefix = name.substring(0, colon);
             String resource = name.substring(colon + 1);
-
-            result = getStyleByName(prefix, resource);
+            if (STRICT_STYLE == true) {
+                result = getStyleByName(prefix, resource);
+            } else {
+                String resource2 = resource.replaceAll(REPLACE, "_");
+                String name2 = name.replaceAll(REPLACE, "_");
+                // check workspace: sty_le
+                result = getStyleByName(prefix, resource2);
+                // check workspace_sty_le
+                result = facade.getStyleByName(name2);
+                // check workspace: sty:le
+                result = getStyleByName(prefix, resource);
+                // check workspace:sty:le
+                result = facade.getStyleByName(name);
+            }
         } 
         if (result == null) {
             result = facade.getStyleByName(name);


### PR DESCRIPTION
Put in place the regex if we want to update for characters other than colon. Otherwise, our strategy is just to replace the bad characters with underscores and scan the catalog for that instead.

Improvement could be made by throwing an exception earlier up the call hierarchy rather than down here in the catalog level.